### PR TITLE
Fix typos & ambiguities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is Exercism's automated analyzer for the Ruby track.
 
-it is run with `./bin/analyze.sh $EXERCISM $PATH_TO_FILES` and will write a JSON file with an analysis to the same directory.
+It is run with `./bin/analyze.sh $EXERCISM $PATH_TO_FILES` and will write a JSON file with an analysis to the same directory.
 
 For example:
 

--- a/lib/analyzers/two_fer/analyze.rb
+++ b/lib/analyzers/two_fer/analyze.rb
@@ -4,7 +4,7 @@ module TwoFer
     no_module: "No module or class called TwoFer",
     no_method: "No method called two_fer",
     splat_args: "Rather than using *%s, how about actually setting a parameter called 'name'?",
-    missing_default_param: "There is not a correct default param - the tests will fail",
+    missing_default_param: "There is no correct default param - the tests will fail",
     incorrect_default_param: "You could set the default value to 'you' to avoid conditionals",
     string_building: "Rather than using string building, use interpolation",
     kernel_format: "Rather than using the format method, use interpolation",
@@ -146,7 +146,7 @@ module TwoFer
       # method rather than insist on it being the first line.
       return unless loc.type == :if
 
-      # Get the clause of the conditional (ie the bit after the "if" keyword)
+      # Get the clause of the conditional (i.e. the bit after the "if" keyword)
       conditional = extract_conditional_clause(loc)
 
       # Let's warn about using a better default if they `if name == nil`
@@ -155,7 +155,7 @@ module TwoFer
         disapprove!(:incorrect_default_param)
       end
 
-      # Same thing but if they do it the other way round, ie `if nil == name`
+      # Same thing but if they do it the other way round, i.e. `if nil == name`
       if conditional.receiver == default_argument &&
          is_lvar?(conditional.first_argument, :name)
         disapprove!(:incorrect_default_param)

--- a/lib/analyzers/two_fer/analyze.rb
+++ b/lib/analyzers/two_fer/analyze.rb
@@ -3,7 +3,7 @@ module TwoFer
   MESSAGES = {
     no_module: "No module or class called TwoFer",
     no_method: "No method called two_fer",
-    splat_args: "Rather than using *%s, how about acutally setting a paramater called 'name'?",
+    splat_args: "Rather than using *%s, how about actually setting a parameter called 'name'?",
     missing_default_param: "There is not a correct default param - the tests will fail",
     incorrect_default_param: "You could set the default value to 'you' to avoid conditionals",
     string_building: "Rather than using string building, use interpolation",
@@ -29,7 +29,7 @@ module TwoFer
       check_method_signature!
 
       # There is one optimal solution for two-fer which needs
-      # no commnents and can just be approved. If we have it, then
+      # no comments and can just be approved. If we have it, then
       # let's just acknowledge it and get out of here.
       check_for_optimal_solution!
 
@@ -40,14 +40,14 @@ module TwoFer
       check_for_correct_solution_without_string_interpolaton!
 
       # The most common error in twofer is people using conditionals
-      # to check where the value passed in is nil, rather than using a defaul
+      # to check where the value passed in is nil, rather than using a default
       # value. We want to check for conditionals and tell the user about the
-      # default paramater if we see one.
+      # default parameter if we see one.
       check_for_conditional_on_default_argument!
 
-      # Sometiems people specify the names (if name == "Alice" ...). If we
+      # Sometimes people specify the names (if name == "Alice" ...). If we
       # do this, suggest using string interpolation to make us of the
-      # paramter, rather than using a conditional on it.
+      # parameter, rather than using a conditional on it.
       # check_for_names!
 
       # We don't have any idea about this solution, so let's refer it to a
@@ -68,7 +68,7 @@ module TwoFer
     def check_method_signature!
       # If there is no parameter or it doesn't have a default value,
       # then this solution won't pass the tests.
-      disapprove!(:missing_default_param) if paramaters.size != 1
+      disapprove!(:missing_default_param) if parameters.size != 1
 
       # If they provide a splat, the tests can pass but we
       # should suggest they use a real paramater
@@ -101,7 +101,7 @@ module TwoFer
     end
 
     def check_for_correct_solution_without_string_interpolaton!
-      # If we don't have a correct default argugment or a one line
+      # If we don't have a correct default argument or a one line
       # solution then let's just get out of here.
       return unless default_argument_is_optimal?
       return unless one_line_solution?
@@ -133,7 +133,7 @@ module TwoFer
       end
 
       # If we have a one-line method that passes the tests, then it's not
-      # soemthing we've planned for, so let's refer it to a mentor
+      # something we've planned for, so let's refer it to a mentor
       return refer_to_mentor!
     end
 
@@ -142,7 +142,7 @@ module TwoFer
 
       # If we don't have a conditional, then let's get out of here.
       #
-      # TODO: We might wnt to refactor this to extract a conditional from the
+      # TODO: We might want to refactor this to extract a conditional from the
       # method rather than insist on it being the first line.
       return unless loc.type == :if
 

--- a/test/exercises/two_fer_test.rb
+++ b/test/exercises/two_fer_test.rb
@@ -122,7 +122,7 @@ class HelloCollectorTest < Minitest::Test
     }
     results = TwoFer::Analyze.(source)
     refute results[:approve]
-    assert_equal ["Rather than using *foos, how about acutally setting a paramater called 'name'?"], results[:messages]
+    assert_equal ["Rather than using *foos, how about actually setting a parameter called 'name'?"], results[:messages]
   end
 
   # ### 

--- a/test/exercises/two_fer_test.rb
+++ b/test/exercises/two_fer_test.rb
@@ -94,7 +94,7 @@ class HelloCollectorTest < Minitest::Test
     }
     results = TwoFer::Analyze.(source)
     refute results[:approve]
-    assert_equal ["There is not a correct default param - the tests will fail"], results[:messages]
+    assert_equal ["There is no correct default param - the tests will fail"], results[:messages]
   end
 
   def test_missing_default_value_fails
@@ -108,7 +108,7 @@ class HelloCollectorTest < Minitest::Test
     }
     results = TwoFer::Analyze.(source)
     refute results[:approve]
-    assert_equal ["There is not a correct default param - the tests will fail"], results[:messages]
+    assert_equal ["There is no correct default param - the tests will fail"], results[:messages]
   end
 
   def test_splat_fails


### PR DESCRIPTION
See diff ;-)

I'm sooo excited to test this! Because the uuid(-like) part of the example path is similar to the uuid in a solution's `download-section`, it had me wondering briefly whether it might work only on the server. Reading the [ReadMe](https://github.com/exercism/ruby-analyzer#exercisms-ruby-analyzer) and "[What we're building](https://github.com/exercism/automated-mentoring-support/blob/master/docs/about.md#what-were-building)" didn't clarify this 100%, but I'm assuming that it will be available locally.

Please feel free to add a review / change request in case the example path could indeed benefit from being updated, e.g. to what `exercism download --exercise=...` creates.