### PR TITLE
Deprecated option --auto-correct

### DIFF
--- a/bin/rubocop-quick
+++ b/bin/rubocop-quick
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs bundle exec rubocop --except Metrics --auto-correct --format quiet --force-exclusion Gemfile && \
+git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs bundle exec rubocop --except Metrics --autocorrect --format quiet --force-exclusion Gemfile && \
 git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs git add


### PR DESCRIPTION
Now uses --autocorrect instead of --auto-correct
