### PR TITLE
Layout/Space inside Hash Literal Braces: no space

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,23 @@ Layout/LineLength:
     - "test/exercises/*"
     - "lib/analyzers/*/analyze.rb"
 
+Layout/SpaceInsideHashLiteralBraces:
+  Description: "Use spaces inside hash literal braces - or don't."
+  StyleGuide: '#spaces-braces'
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+    # 'compact' normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStylesForEmptyBraces:
+    - space
+    - no_space
+
 Lint/SuppressedException:
   Exclude:
     - "test/**/*"

--- a/lib/analyzers/acronym/representation.rb
+++ b/lib/analyzers/acronym/representation.rb
@@ -11,7 +11,7 @@ module Acronym
         },
         {
           method_name: :map,
-          arguments: [{ to_ast: s(:block_pass, s(:sym, :chr)) }],
+          arguments: [{to_ast: s(:block_pass, s(:sym, :chr))}],
           chained?: true
         },
         {
@@ -22,7 +22,7 @@ module Acronym
           method_name: :tr,
           receiver: ArbitraryLvar.new,
           chained?: true,
-          arguments: [{ to_ast: s(:str, "-") }, { to_ast: s(:str, " ") }]
+          arguments: [{to_ast: s(:str, "-")}, {to_ast: s(:str, " ")}]
         }
       ]
 
@@ -56,7 +56,7 @@ module Acronym
           method_name: :tr,
           receiver: ArbitraryLvar.new,
           chained?: true,
-          arguments: [{ to_ast: s(:str, "-") }, { to_ast: s(:str, " ") }]
+          arguments: [{to_ast: s(:str, "-")}, {to_ast: s(:str, " ")}]
         },
         {
           method_name: :chr,
@@ -80,7 +80,7 @@ module Acronym
           method_name: :scan,
           receiver: ArbitraryLvar.new,
           chained?: true,
-          arguments: [{ type: :regexp }]
+          arguments: [{type: :regexp}]
         }
       ]
 
@@ -99,12 +99,12 @@ module Acronym
         {
           method_name: :map,
           chained?: true,
-          arguments: [{ to_ast: s(:block_pass, s(:sym, :chr)) }]
+          arguments: [{to_ast: s(:block_pass, s(:sym, :chr))}]
         },
         {
           method_name: :split,
           receiver: ArbitraryLvar.new,
-          arguments: [{ type: :regexp }]
+          arguments: [{type: :regexp}]
         }
       ]
 

--- a/lib/analyzers/two_fer/analyze.rb
+++ b/lib/analyzers/two_fer/analyze.rb
@@ -51,7 +51,7 @@ module TwoFer
     # is sane and that it has valid arguments
     def check_method_signature!
       disapprove!(:missing_default_param) unless solution.has_one_parameter?
-      disapprove!(:splat_args, { name_variable: solution.first_parameter_name }) if solution.uses_splat_args?
+      disapprove!(:splat_args, {name_variable: solution.first_parameter_name}) if solution.uses_splat_args?
       disapprove!(:missing_default_param) unless solution.first_paramater_has_default_value?
     end
 
@@ -77,7 +77,7 @@ module TwoFer
 
       if solution.uses_string_interpolation?
         if solution.string_interpolation_is_correct?
-          approve_if_implicit_return!(:string_interpolation, { name_variable: solution.first_parameter_name })
+          approve_if_implicit_return!(:string_interpolation, {name_variable: solution.first_parameter_name})
         else
           refer_to_mentor!
         end
@@ -85,17 +85,17 @@ module TwoFer
 
       # "One for " + name + ", one for me."
       if solution.uses_string_concatenation?
-        approve_if_implicit_return!(:string_concatenation, { name_variable: solution.first_parameter_name })
+        approve_if_implicit_return!(:string_concatenation, {name_variable: solution.first_parameter_name})
       end
 
       # format("One for %s, one for me.", name)
       if solution.uses_kernel_format?
-        approve_if_implicit_return!(:kernel_format, { name_variable: solution.first_parameter_name })
+        approve_if_implicit_return!(:kernel_format, {name_variable: solution.first_parameter_name})
       end
 
       # "One for %s, one for me." % name
       if solution.uses_string_format?
-        approve_if_implicit_return!(:string_format, { name_variable: solution.first_parameter_name })
+        approve_if_implicit_return!(:string_format, {name_variable: solution.first_parameter_name})
       end
 
       # If we have a one-line method that passes the tests, then it's not
@@ -161,7 +161,7 @@ module TwoFer
 
     def approve_if_whitespace_is_sensible!(msg = nil, params = {})
       if solution.indentation_is_sensible?
-        self.comments << { comment: MESSAGES[msg], params: } if msg
+        self.comments << {comment: MESSAGES[msg], params:} if msg
         self.status = :approve
 
         raise FinishedFlowControlException
@@ -180,7 +180,7 @@ module TwoFer
     def disapprove!(msg, params = {})
       self.status = :disapprove
       self.comments << if params.length > 0
-                         { comment: MESSAGES[msg], params: }
+                         {comment: MESSAGES[msg], params:}
                        else
                          MESSAGES[msg]
                        end

--- a/test/exercises/two_fer_test.rb
+++ b/test/exercises/two_fer_test.rb
@@ -139,7 +139,7 @@ class TwoFerTest < Minitest::Test
     }
     results = TwoFer::Analyze.(source)
     assert_equal :disapprove, results[:status]
-    assert_equal [{ comment: "ruby.two-fer.splat_args", params: { name_variable: :foos } }], results[:comments]
+    assert_equal [{comment: "ruby.two-fer.splat_args", params: {name_variable: :foos}}], results[:comments]
   end
 
   # ###
@@ -156,7 +156,7 @@ class TwoFerTest < Minitest::Test
     '
     results = TwoFer::Analyze.(source)
     assert_equal :approve, results[:status]
-    assert_equal [{ comment: "ruby.two-fer.string_concatenation", params: { name_variable: :name } }], results[:comments]
+    assert_equal [{comment: "ruby.two-fer.string_concatenation", params: {name_variable: :name}}], results[:comments]
   end
 
   def test_string_interpolation_passes
@@ -169,7 +169,7 @@ class TwoFerTest < Minitest::Test
     }
     results = TwoFer::Analyze.(source)
     assert_equal :approve, results[:status]
-    assert_equal [{ comment: "ruby.two-fer.string_interpolation", params: { name_variable: :name } }], results[:comments]
+    assert_equal [{comment: "ruby.two-fer.string_interpolation", params: {name_variable: :name}}], results[:comments]
   end
 
   def test_for_kernel_format
@@ -183,7 +183,7 @@ class TwoFerTest < Minitest::Test
     '
     results = TwoFer::Analyze.(source)
     assert_equal :approve, results[:status]
-    assert_equal [{ comment: "ruby.two-fer.kernel_format", params: { name_variable: :name } }], results[:comments]
+    assert_equal [{comment: "ruby.two-fer.kernel_format", params: {name_variable: :name}}], results[:comments]
   end
 
   def test_for_string_format
@@ -197,7 +197,7 @@ class TwoFerTest < Minitest::Test
     '
     results = TwoFer::Analyze.(source)
     assert_equal :approve, results[:status]
-    assert_equal [{ comment: "ruby.two-fer.string_format", params: { name_variable: :name } }], results[:comments]
+    assert_equal [{comment: "ruby.two-fer.string_format", params: {name_variable: :name}}], results[:comments]
   end
 
   def test_conditional_as_boolean


### PR DESCRIPTION
This differentiates from block syntax where there should be space inside
the delimiters, and mirrors other collection literals, where no space is
placed inside their delimiters, keeping a consistent communication.

Ref: #114
