### PR TITLE
Add high-scores filename

### DIFF
--- a/lib/analyzer.rb
+++ b/lib/analyzer.rb
@@ -8,7 +8,8 @@ EXERCISES = %w[
 FILENAMES = {
   "acronym" => "acronym.rb",
   "two-fer" => "two_fer.rb",
-  "leap" => "leap.rb"
+  "leap" => "leap.rb",
+  "high-scores" => "high_scores.rb"
 }.freeze
 
 require 'mandate'


### PR DESCRIPTION
This is a follow up to #113. The filename needs to be added for the analyzer to work correctly. I can add a test in another PR to catch this.