### PR TITLE
Remove `pry` gem and references

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,5 @@ group :test do
   gem 'minitest'
   gem 'minitest-stub-const'
   gem 'mocha'
-  gem 'pry'
   gem 'simplecov', '~> 0.17.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,6 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
-    coderay (1.1.3)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     docile (1.4.0)
@@ -24,7 +23,6 @@ GEM
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     mandate (2.2.0)
-    method_source (1.1.0)
     minitest (5.24.1)
     minitest-stub-const (0.6)
     mocha (2.4.0)
@@ -34,9 +32,6 @@ GEM
     parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -83,7 +78,6 @@ DEPENDENCIES
   minitest-stub-const
   mocha
   parser
-  pry
   rake
   rubocop
   rubocop-minitest

--- a/scripts/manual_test.rb
+++ b/scripts/manual_test.rb
@@ -1,6 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require "analyzer"
-require 'pry'
 
 source = %q{
 class TwoFer

--- a/test/exercises/acronym_test.rb
+++ b/test/exercises/acronym_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require 'pry'
 
 class AcronymTest < Minitest::Test
   def test_method_chaining_passes

--- a/test/exercises/two_fer_test.rb
+++ b/test/exercises/two_fer_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require 'pry'
 
 class TwoFerTest < Minitest::Test
   def test_fixtures

--- a/test/generic/extract_instance_method_test.rb
+++ b/test/generic/extract_instance_method_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require 'pry'
 
 module SA
   class ExtractInstanceMethodTest < Minitest::Test

--- a/test/generic/extract_module_method_test.rb
+++ b/test/generic/extract_module_method_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require 'pry'
 
 module SA
   class ExtractModuleMethodTest < Minitest::Test

--- a/test/generic/extract_module_or_class_test.rb
+++ b/test/generic/extract_module_or_class_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require 'pry'
 
 module SA
   class ExtractModuleOrClassTest < Minitest::Test

--- a/test/generic/helpers_test.rb
+++ b/test/generic/helpers_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require 'pry'
 
 module SA
   class HelpersTest < Minitest::Test


### PR DESCRIPTION
This removes a library that is not actively used, and is not a
dependency of the code here in the repository.
